### PR TITLE
more correct processing of non-img elements

### DIFF
--- a/src/controllers/layouts.js
+++ b/src/controllers/layouts.js
@@ -4,7 +4,7 @@ function detectImagesLoaded (element) {
     const images = Array.from(element.querySelectorAll('img') || []);
 
     if (images.length === 0) {
-        return;
+        return Promise.resolve();
     }
 
     return Promise.all(images.map((image) => {


### PR DESCRIPTION
if i try to paste to MarkerLayout non-img element, i catch the exception of calling .then from result of detectImagesLoaded function (returns undefined if no images passed to MarkerLayout)
